### PR TITLE
fix(README.md): tiny link error in contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![JavaScript Style Guide](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)
 
 # Contributors:
-|[Sangoon_Is_Noob](https://github.com/cotwo0139)|
-|------|
-|![Sangoon_Profile_SRC](https://chinobot.ga/author_profile.png)|
+| [Sangoon_Is_Noob](https://github.com/sannoob)                  |
+|----------------------------------------------------------------|
+| ![Sangoon_Profile_SRC](https://chinobot.ga/author_profile.png) |
 
 Interested this project? [Contribute this project!](https://github.com/cotwo0139/slyrics/pulls)
 


### PR DESCRIPTION
fix tiny link error in contributors section:
use your correct profile link _https://github.com/sannoob (200 OK)_ instead _https://github.com/cotwo0139 (404 Not Found)_